### PR TITLE
Add Android Studio inspections info and reorg’d doc by IDE

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,52 +1,33 @@
-## Two Toasters Android Coding Style Guidelines
+# Two Toasters Android Style Guidelines
 
-#### Checkstyle
+## Android Studio
 
-The Checkstyle code styling plugin is available for both Eclipse and Android Studio IDEs.
+Setting up Android Studio for your project will involve two tasks: (1) declaring inspections and (2) enabling Checkstyle.
 
-##### Eclipse
+### Inspections
 
-Install and setup the Checkstyle Eclipse plugins.
-	
-Update site: <http://eclipse-cs.sourceforge.net/update/>
-	
-- Install both plugings from the update site
-- Copy checkstyle.xml file to root of your project
-- Activate Checkstyle during new project setup
-	1. Right click project > Properties then choose Checkstyle from left side
-	2. Enable "Checkstyle active for this project"
-	3. Enable "Use simple configuration"
-	4. Switch to "Local Check Configuration" tab
-	5. Add a New local configuration
-		- Set type: project relative configuration
-		- Set name: "checkstyle xml file"
-		- Set location: root of project
-	6. Fix unresolved items
-		- Click additional properties button
-		- Click find unresolved properties button
-		- Declare "checkstyle.cache.file" as "bin/cachefile"
-	7. Switch to "Main" tab
-	8. Set the configuration to use to the "checkstyle xml file" local config
-	9. Exclude files outside the source directories & from packages "gen"
+The following items are similar to Eclipse's Save Actions.
 
-##### Android Studio
+1. Open Studio and go to Preferences
+2. Go to Project Settings > Code Style > Java
+3. Choose the Imports tab and enable *Insert imports for inner classes*
+4. Back on the left pane, go to Project Settings > Inspections
+5. Search for *Unused Import* and enable the checkbox so they will be removed when saving files
 
-Install and setup the Checkstyle-IDEA plugin.
+### Checkstyle
 
-Plugin url: <http://plugins.jetbrains.com/plugin/1065>
+Checkstyle for Android Studio comes in two parts (1) the IDE and (2) the gradle build. Checkstyle in the IDE only alerts you to errors and warnings, whereas the build task is the part that will actually fail the build so you know you have issues. Only the first dev to set up the project will need to add Checkstyle build support, but all devs will need to install the IDE support.
+
+#### IDE Support
+
+Install and setup the [Checkstyle-IDEA plugin](http://plugins.jetbrains.com/plugin/1065).
 
 - Download and install the latest version of the plugin
 	1. Download the plugin to disk
 	2. Open Android Studio and go to preferences
 	3. IDE Settings > Plugins > Install plugin from disk (select file you downloaded)
 	4. Once plugin is installed, it will ask you to restart studio
-
 - Copy checkstyle.xml file to root of your project
-- Create a symlink to the checkstyle.xml from the project root that contains the file
-
-        mkdir -p config/checkstyle  
-        ln -s ../../checkstyle.xml config/checkstyle/checkstyle.xml
-
 - Activate Checkstyle in Android Studio IDE during new project setup
 	1. Open Studio and go back to Preferences
 	2. Go to Project Settings > Inspections and then search for Checkstyle
@@ -59,6 +40,14 @@ Plugin url: <http://plugins.jetbrains.com/plugin/1065>
 	9. Enter "bin/cachefile" as the property for "checkstyle.cache.file"
 	10. Choose OK and activate the new config
 	11. Hit apply and then OK
+
+#### Gradle Build Support
+
+- Create a symlink to the checkstyle.xml from the project root that contains the file
+
+        mkdir -p config/checkstyle  
+        ln -s ../../checkstyle.xml config/checkstyle/checkstyle.xml
+
 - Activate Checkstyle in Gradle build file: `build.gradle`
 	1. Apply checkstyle plugin
 
@@ -85,7 +74,34 @@ Plugin url: <http://plugins.jetbrains.com/plugin/1065>
 
 			preBuild.dependsOn('checkstyle')
 
-#### Save Actions
+## Eclipse
+
+### Checkstyle
+
+Install and setup the Checkstyle Eclipse plugins.
+	
+Update site: <http://eclipse-cs.sourceforge.net/update/>
+	
+- Install both plugings from the update site
+- Copy checkstyle.xml file to root of your project
+- Activate Checkstyle during new project setup
+	1. Right click project > Properties then choose Checkstyle from left side
+	2. Enable "Checkstyle active for this project"
+	3. Enable "Use simple configuration"
+	4. Switch to "Local Check Configuration" tab
+	5. Add a New local configuration
+		- Set type: project relative configuration
+		- Set name: "checkstyle xml file"
+		- Set location: root of project
+	6. Fix unresolved items
+		- Click additional properties button
+		- Click find unresolved properties button
+		- Declare "checkstyle.cache.file" as "bin/cachefile"
+	7. Switch to "Main" tab
+	8. Set the configuration to use to the "checkstyle xml file" local config
+	9. Exclude files outside the source directories & from packages "gen"
+
+### Save Actions
 
 Enable save actions in the global workspace preferences.
 


### PR DESCRIPTION
The only new stuff is the Inspections section for Android Studio, otherwise I just reorganized the document by IDE to make setup easier.
